### PR TITLE
Add Swift 5.0 Release support

### DIFF
--- a/OnlinePlayground/OnlinePlayground-5.0-RELEASE/Package.resolved
+++ b/OnlinePlayground/OnlinePlayground-5.0-RELEASE/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "CryptoSwift",
+        "repositoryURL": "https://github.com/krzyzanowskim/CryptoSwift.git",
+        "state": {
+          "branch": null,
+          "revision": "ea8c0769151d7d9587e1768094a517890114391e",
+          "version": "0.10.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/OnlinePlayground/OnlinePlayground-5.0-RELEASE/Package.swift
+++ b/OnlinePlayground/OnlinePlayground-5.0-RELEASE/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version:4.2
+import PackageDescription
+
+let dependencies:[Package.Dependency] = [
+    .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", .exact("0.10.0"))
+]
+
+var targets:[Target] = [
+    .target(name: "OnlinePlayground", dependencies: ["CryptoSwift"]), // Link custom modules here
+]
+
+var products: [Product] = [
+    .library(name: "OnlinePlayground", type: .static, targets: ["OnlinePlayground"])
+]
+
+let package = Package(
+    name: "OnlinePlayground",
+    products: products,
+    dependencies: dependencies,
+    targets: targets
+)

--- a/OnlinePlayground/OnlinePlayground-5.0-RELEASE/Sources
+++ b/OnlinePlayground/OnlinePlayground-5.0-RELEASE/Sources
@@ -1,0 +1,1 @@
+../OnlinePlayground-Shared/Sources/

--- a/Sources/Application/BuildToolchain/BuildToolchain.swift
+++ b/Sources/Application/BuildToolchain/BuildToolchain.swift
@@ -17,6 +17,7 @@ enum SwiftToolchain: String, RawRepresentable, Codable {
     case swift4_0_3 = "4.0.3-RELEASE"
     case swift4_1 = "4.1.2-RELEASE"
     case swift4_2 = "4.2-RELEASE"
+    case swift5_0 = "5.0-RELEASE"
 
     // Path to toolchain, relative to current process PWD
     var path: AbsolutePath {
@@ -33,7 +34,7 @@ class BuildToolchain {
 
     private let processSet = ProcessSet()
 
-    func build(code: String, toolchain: SwiftToolchain = .swift4_2) throws -> Result<AbsolutePath, Error> {
+    func build(code: String, toolchain: SwiftToolchain = .swift5_0) throws -> Result<AbsolutePath, Error> {
         let fileSystem = Basic.localFileSystem
         let projectDirectoryPath = AbsolutePath(FileKit.projectFolder)
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -57,17 +57,20 @@ $(npm bin)/webpack
 
 if [ $(program_is_installed xcrun) == 1 ]; then
     # Install Toolchains
+    install_toolchain "5.0" "release" "RELEASE" "osx"
     install_toolchain "4.2" "release" "RELEASE" "osx"
     install_toolchain "4.1.2" "release" "RELEASE" "osx"
     install_toolchain "4.0.3" "release" "RELEASE" "osx"
 else
     # Install Toolchains
+    install_toolchain "5.0" "release" "RELEASE" "ubuntu14.04"
     install_toolchain "4.2" "release" "RELEASE" "ubuntu14.04"
     install_toolchain "4.1.2" "release" "RELEASE" "ubuntu14.04"
     install_toolchain "4.0.3" "release" "RELEASE" "ubuntu14.04"
 fi
 
 # Build OnlinePlayground
+build_onlineplayground "5.0" "RELEASE"
 build_onlineplayground "4.2" "RELEASE"
 build_onlineplayground "4.1.2" "RELEASE"
 build_onlineplayground "4.0.3" "RELEASE"

--- a/frontend/swift-versions.js
+++ b/frontend/swift-versions.js
@@ -8,7 +8,7 @@ export default class SwiftVersion extends React.Component {
         super(props);
         uniqueId.enableUniqueIds(this)
 
-        this.availableVersions = ["4.0.3-RELEASE", "4.1.2-RELEASE", "4.2-RELEASE"]
+        this.availableVersions = ["4.0.3-RELEASE", "4.1.2-RELEASE", "4.2-RELEASE", "5.0-RELEASE"]
         this.state = {
             currentVersion: this.availableVersions.slice(-1).pop()
         }


### PR DESCRIPTION
Adds support for Swift 5 and defaults the selection to it.

Building and running Docker commands created and modified 2 files that are not in this pull request. (https://github.com/alvarhansen/OnlineSwiftPlayground/commit/2d182088e230b51ed74cf07a94ed516fbab73481). Should these be included or is it fine for build process to generate them?