### PR TITLE
Added bindings for the COMMAND + ENTER (Mac) and CTRL + ENTER (Linux, Windows)

### DIFF
--- a/frontend/editor.js
+++ b/frontend/editor.js
@@ -11,7 +11,8 @@ class Editor extends React.Component {
       code: props.code,
       readOnly: props.readOnly,
       showLines: !props.readOnly,
-      language: props.readOnly == true ? "plaintext" : "swift"
+      language: props.readOnly == true ? "plaintext" : "swift",
+	  commandHandler: props.commandHandler,
     };
   }
 
@@ -21,6 +22,7 @@ class Editor extends React.Component {
 
   editorDidMount(editor, monaco) {
     this.editor = editor;
+	editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter, this.state.commandHandler);
 
     $.getJSON("/static/assets/json/snippets.json", function(snippets) {
       monaco.languages.registerCompletionItemProvider("swift", {

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -24,7 +24,7 @@ let swiftVersionComponent = ReactDOM.render(
 )
 
 let editorComponent = ReactDOM.render(
-  <Editor />,
+  <Editor commandHandler = {dispatchEvaluationRequest}/>,
   document.getElementById("editor")
 );
 
@@ -43,6 +43,10 @@ let playground = new Playground(protocol, editorComponent.editor);
 // Install events
 $("#run-button").click(function (e) {
   e.preventDefault();
+  dispatchEvaluationRequest();
+});
+
+function dispatchEvaluationRequest() {
   let sender = $(this);
   sender.prop("disabled", true);
 
@@ -51,7 +55,7 @@ $("#run-button").click(function (e) {
     sender.prop("disabled", false);
     editorComponent.editor.focus();
   });
-});
+}
 
 $("#download-file-button").click(function (e) {
   let text = editorComponent.getValue();


### PR DESCRIPTION
This addresses #16. Added bindings for the COMMAND + ENTER (Mac) and CTRL + ENTER (Linux, Windows) key combinations. These key combinations will now trigger an immediate dispatch of the evaluation call to the Swift Playground back-end. Essentially, whatever currently happens on clicking the Run button, can now be triggered via these key combinations.